### PR TITLE
Fix sw docker build bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ build/
 *.o
 uart
 work-ver/*
-corev_apu
 corev_apu/fpga/work-fpga
 corev_apu/fpga/reports/
 corev_apu/fpga/scripts/add_sources.tcl

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build/
 *.o
 uart
 work-ver/*
+corev_apu
 corev_apu/fpga/work-fpga
 corev_apu/fpga/reports/
 corev_apu/fpga/scripts/add_sources.tcl

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,5 @@ RUN useradd -u $UID -m -g user -G plugdev user \
 
 USER user
 
-
-
-
+RUN cd /home/user && \
+	echo "PS1='\[\e[38;5;33m\](sw-docker container) \[\e[38;5;247m\]\u\[\e[0m\]@\[\e[38;5;33m\]\H\[\e[0m\]:\[\e[96;3m\]\w \[\e[0m\]\\$ '" >> .bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN apt-get -y update && \
 
 
 # install openOCD
-RUN git clone https://github.com/openocd-org/openocd && \
+RUN git clone --recursive https://github.com/openocd-org/openocd && \
     cd openocd && \
     git checkout v0.11.0 && \
     mkdir build && \


### PR DESCRIPTION
# What does this PR do ?

Fix bug when building sw dicker image
Update .gitignore to avoid uploading build files to this repo.

# Why merge this PR ?

I noticed when trying to build sw docker image with this command :

```
docker build -f Dockerfile --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t sw-docker:v1 .
```

That this cloning of openOCD takes too much time and times out.
So i triedon my own environement to clone openOCD repo adding the `--recursive` flag and it worked

So i added it to the Dockerfile

About the .gitignore : 
I updated it because i did not want to upload a bunch of fpga build stuff.
If it is not necessary, do not hesitate do modify before merge.

Best regards,
BRH